### PR TITLE
[WIP]chat-spaceのデータベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,13 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false|
+|name|string|null: false,index: true|
 |email|string|null: false, add_index :users, :email, unique: true|
 |encrypted_password|string|null: false|
 
 ### Association
 - has_many :groups_users
 - has_many :groups, through: :groups_users
-- has_many :groups_members
-- has_many :groups, through: :groups_members
 - has_many :messages
 
 
@@ -43,13 +41,11 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users
-- has_many :groups_members
-- has_many :users, through: :groups_members
 - has_many :messages
 
 
@@ -57,10 +53,10 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -71,21 +67,10 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
 - belongs_to :user
 
-
-## groups_membersテーブル
-
-|Column|Type|Options|
-|------|----|-------|
-|user_id|integer|null: false, foreign_key: true,add_index:users,:name|
-|group_id|integer|null: false, foreign_key: true|
-
-### Association
-- belongs_to :group
-- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -22,3 +22,70 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false, add_index :users, :email, unique: true|
+|encrypted_password|string|null: false|
+
+### Association
+- has_many :groups_users
+- has_many :groups, through: :groups_users
+- has_many :groups_members
+- has_many :groups, through: :groups_members
+- has_many :messages
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+
+### Association
+- has_many :groups_users
+- has_many :users, through: :groups_users
+- has_many :groups_members
+- has_many :users, through: :groups_members
+- has_many :messages
+
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## groups_membersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true,add_index:users,:name|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user


### PR DESCRIPTION
# What
chat-spaceのデータベース設計
usersテーブル。groupsテーブル。messagesテーブルを作成。
中間テーブルとして、groups_usersテーブル、groups_membersテーブルを作成。
それぞれをアソシエーションで結合。中間テーブルには、has_many thought オプションを使用。

# Why
ユーザーの情報（名前、メールアドレス、パスワード、id）を入力保存するusersテーブル。
グループの情報（グループの名前、id）を保存、作成するgroupsテーブル。
グループの誰がチャットメンバーか。どのグループかを指定するgroups_usersテーブル。
タグ要素であるグループのメンバーを追加、検索するgroups_membersテーブル。
どのグループで、誰が、メッセージ、イメージを送ったかを管理するmessagesテーブルをそれぞれ作成。