### PR TITLE
ChatSpaceメッセージ送信の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -264,7 +261,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,61 @@
+$(function(){
+  function buildHTML(message){
+    if (message.image) {
+      var html = 
+      `<div class="message__box">
+        <div class="message__box__info">
+          <div class="message__box__info__talker">
+            ${message.user_name}
+          </div>
+          <div class="message__box__info__date">
+            ${message.created_at}
+          </div>
+        </div>
+        <div class="message__box__text">
+          <p class="message__box__content">
+            ${message.content}
+          </p>
+        </div>
+        <img src=${message.image} >
+      </div>`
+      return html
+    } else {
+      var html = 
+      `<div class="message__box">
+        <div class="message__box__info">
+          <div class="message__box__info__talker">
+            ${message.user_name}
+          </div>
+          <div class="message__box__info__date">
+            ${message.created_at}
+          </div>
+        </div>
+        <div class="message__box__text">
+          <p class="message__box__content">
+            ${message.content}
+          </p>
+        </div>
+      </div>`
+      return html;
+    };
+  }
+
+  $('#new_message').on('submit',function(e){
+    e.preventDefault()
+    var formData = new FormData (this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,  
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);      
+      $('form')[0].reset();
+    })
+  })
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -57,6 +57,10 @@ $(function(){
       $('.message').append(html);
       $('form')[0].reset();
       $('.message').animate({ scrollTop: $('.message')[0].scrollHeight});
+      $('.submit-btn').attr('disabled', false);
     })
+    .fail(function() {
+      alert("メッセージ送信に失敗しました");
+    });
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -54,8 +54,9 @@ $(function(){
     })
     .done(function(data){
       var html = buildHTML(data);
-      $('.messages').append(html);      
+      $('.message').append(html);
       $('form')[0].reset();
+      $('.message').animate({ scrollTop: $('.message')[0].scrollHeight});
     })
   })
 });

--- a/app/assets/stylesheets/modules/_main_chat.scss
+++ b/app/assets/stylesheets/modules/_main_chat.scss
@@ -50,6 +50,7 @@ $dark-color:#434a54;
     height: calc(100vh - 190px);
     padding: 35px 40px;
     box-sizing: border-box;
+    overflow: scroll;
     &__box{
       padding-bottom: 46px;
       &__info{

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,10 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,6 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,11 +1,11 @@
-.message
-  .upper-message
-    .upper-message__user-name
+.message__box
+  .message__box__info
+    .message__box__info__talker
       = message.user.name
-    .upper-message__date
+    .message__box__info__date
       = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-  .lower-message
+  .message__box__text
     - if message.content.present?
-      %p.lower-message__content
+      %p.message__box__content
         = message.content
     = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
# What
フォームが送信されたらイベントが発火するように実装。
ajaxとformDateを使用。messages#createが動くようにする。
respond_toを使用し、処理を分ける。
app/views/messages/create.json.jbuildeを作成。メッセージをJSON形式で返す。
JSONをdoneメソッドで受取り、HTMLを作成。
appendメソッドを使用し、受け取ったHTMLを一番最後に追加。.rest()でフォームを空にする。
animateメゾットを使用し、メッセージを送信したとき、メッセージ画面を最下部にスクロールさせる。
連続で送信ボタンを押せるようにsubmitのdisabledをfalseに。
失敗した場合のalertを追記し、日時表示をconfig.time_zone = 'Tokyo'で日本時間に修正。

# Why
ユーザーの動作を止めることなく、連続的に作業を続けられ、高速に画面を書き換えられる。
効率よくスピーディーにページを書き換えられるAjaxは必須の機能なので追加